### PR TITLE
Support HTTPS

### DIFF
--- a/jquery.browserLanguage.js
+++ b/jquery.browserLanguage.js
@@ -23,7 +23,7 @@
    $.browserLanguage = function(callback){
      var language;
      $.ajax({
-         url: "http://ajaxhttpheaders.appspot.com",
+         url: "//ajaxhttpheaders.appspot.com",
          dataType: 'jsonp',
          success: function(headers) {
              language = headers['Accept-Language'].substring(0,2);


### PR DESCRIPTION
Use a protocol-less URL to call service which determines accept language. Thus we avoid any security warnings when this plugin is used on a page served using HTTPS.
