### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,6 @@ Example usage:
 </script>
 ```
 
-##Update 30th April 2015
+## Update 30th April 2015
 
 If you want to run your own version of the App Engine app, you can find it here: https://github.com/dansingerman/app-engine-headers


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
